### PR TITLE
<Hero> class exception for get_heroes

### DIFF
--- a/srcds/addons/source-python/plugins/warcraft/heroes/__init__.py
+++ b/srcds/addons/source-python/plugins/warcraft/heroes/__init__.py
@@ -33,7 +33,7 @@ def get_heroes():
         module = importlib.import_module('warcraft.heroes.' + module_name)
         
         for obj_name, obj in inspect.getmembers(module):
-            if obj_name.startswith('_') or obj_name == 'Hero':
+            if obj_name.startswith('_') or obj is Hero:
                 continue
             if inspect.isclass(obj) and issubclass(obj, Hero):
                 yield obj

--- a/srcds/addons/source-python/plugins/warcraft/heroes/__init__.py
+++ b/srcds/addons/source-python/plugins/warcraft/heroes/__init__.py
@@ -33,7 +33,7 @@ def get_heroes():
         module = importlib.import_module('warcraft.heroes.' + module_name)
         
         for obj_name, obj in inspect.getmembers(module):
-            if obj_name.startswith('_'):
+            if obj_name.startswith('_') or obj_name == 'Hero':
                 continue
             if inspect.isclass(obj) and issubclass(obj, Hero):
                 yield obj


### PR DESCRIPTION
Had to add this because upon importing Hero into a hero module. Inspect then asumes that <Hero> is now a class member of the new hero module. It then returns <Hero> as 1 of its members from that module.

To replicate this just make a hero inside the "heroes" folder and then check the "heroes" global in the main python file. "heroes" global now contains the <Hero> class as 1 of it items.