### PR TITLE
Fixed a bug for initialising heroes

### DIFF
--- a/srcds/addons/source-python/plugins/warcraft/warcraft.py
+++ b/srcds/addons/source-python/plugins/warcraft/warcraft.py
@@ -285,6 +285,8 @@ def _on_change_hero_menu_build(menu, player_index):
     total_level = player.calculate_total_level()
     for hero_id, hero_class in heroes.items():
         if hero_id in player.heroes or hero_class.required_level <= total_level:
+            if hero_id not in player.heroes:
+                player.heroes[hero_id] = hero_class(player)
             text = _tr['Owned Hero Text'].get_string(hero=player.heroes[hero_id])
             menu.append(PagedOption(text, hero_class, True, True))
         else:


### PR DESCRIPTION
This fixed a bug in which when you first aquire a hero due to levelling up past the required level. It would parse through to line 290 and get stuck because the total level statement was satisfied, however the hero id would not appear in the heroes player dict.